### PR TITLE
fix Scheduler[Future] implementation

### DIFF
--- a/core-io/src/main/scala/com/itv/servicebox/interpreter/package.scala
+++ b/core-io/src/main/scala/com/itv/servicebox/interpreter/package.scala
@@ -22,8 +22,7 @@ package object interpreter {
         implicit ec: ExecutionContext): IO[A] = {
 
       val timer                        = implicitly[Timer[IO]]
-      def getRealTime                  = timer.clockRealTime(TimeUnit.MILLISECONDS)
-      def elapsedTime(startTime: Long) = getRealTime.map(_ - startTime)
+      def getRealTime                  = timer.clockMonotonic(TimeUnit.MILLISECONDS)
 
       def attemptAction(timeTaken: Long): IO[A] =
         for {

--- a/core/src/main/scala/com.itv/servicebox/algebra/Scheduler.scala
+++ b/core/src/main/scala/com.itv/servicebox/algebra/Scheduler.scala
@@ -1,9 +1,12 @@
 package com.itv.servicebox.algebra
 
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.{ScheduledExecutorService, TimeUnit, TimeoutException}
+import java.util.function.LongUnaryOperator
 
 import cats.instances.future._
 import cats.syntax.flatMap._
+
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.control.NonFatal
@@ -16,38 +19,35 @@ abstract class Scheduler[F[_]](logger: Logger[F]) {
 object Scheduler {
   implicit def futureScheduler(implicit executor: ScheduledExecutorService, logger: Logger[Future]): Scheduler[Future] =
     new Scheduler[Future](logger) {
-      override def retry[A](f: () => Future[A], interval: FiniteDuration, timeout: FiniteDuration, label: String)(
+      override def retry[A](f: () => Future[A], checkTimeout: FiniteDuration, totalTimeout: FiniteDuration, label: String)(
           implicit ec: ExecutionContext): Future[A] =
         f().recoverWith {
           case NonFatal(_) =>
             val promise = Promise[A]()
+            val elapsedTime = new AtomicLong(0L)
+            val incrementElapsedTime = new LongUnaryOperator {
+              override def applyAsLong(time: Long): Long = time + checkTimeout.toMillis
+            }
 
-            val backgroundTask = executor.scheduleAtFixedRate(
-              new Runnable {
-                override def run() =
-                  (logger.debug(s"attempting to run ready check for service $label") >> f()).onComplete {
-                    case scala.util.Success(a) =>
-                      if (!promise.isCompleted)
-                        promise.success(a)
-                    case scala.util.Failure(err) =>
-                      logger.warn(s"promise already fulfilled: $err")
-                  }
-              },
-              0L,
-              interval.toMillis,
-              TimeUnit.MILLISECONDS
-            )
+            def checkUntilTotalTimeout(): Unit = {
+              val msg = s"attempting to run ready check for service $label [elapsed time: ${elapsedTime.get()}, totalTimeout ms: ${totalTimeout.toMillis}]"
+              (logger.debug(msg) >> f()).onComplete {
+                 case scala.util.Success(a) =>
+                   if (!promise.isCompleted)
+                     promise.success(a)
+                   else logger.warn("ready-check is running with an already completed promise. This should not happen!")
+                 case scala.util.Failure(err) =>
+                   logger.debug(s"ready-check failed: $err")
 
-            executor.schedule(
-              new Runnable {
-                override def run() = {
-                  backgroundTask.cancel(true)
-                  promise.failure(new TimeoutException(s"ReadyCheck $label timed out!"))
-                }
-              },
-              timeout.toMillis,
-              TimeUnit.MILLISECONDS
-            )
+                   if (elapsedTime.getAndUpdate(incrementElapsedTime) < totalTimeout.toMillis) {
+                     executor.schedule(new Runnable {
+                       override def run() = checkUntilTotalTimeout()
+                     }, checkTimeout.toMillis, TimeUnit.MILLISECONDS)
+                   } else promise.failure(new TimeoutException(s"ReadyCheck $label timed out!"))
+              }
+            }
+
+            checkUntilTotalTimeout()
 
             promise.future >>= (x =>
               logger.debug(s"""ready check completed for service: $label (promise: $promise)""").map(_ => x))

--- a/core/src/main/scala/com.itv/servicebox/algebra/ServiceController.scala
+++ b/core/src/main/scala/com.itv/servicebox/algebra/ServiceController.scala
@@ -58,6 +58,6 @@ class ServiceController[F[_]](logger: Logger[F],
   def waitUntilReady(service: Service.Registered[F])(implicit ec: ExecutionContext): F[Unit] = {
     def check = () => service.readyCheck.isReady(service.endpoints)
     val label = service.readyCheck.label.getOrElse(service.ref.show)
-    scheduler.retry(check, service.readyCheck.checkInterval, service.readyCheck.timeout, label)
+    scheduler.retry(check, service.readyCheck.attemptTimeout, service.readyCheck.totalTimeout, label)
   }
 }

--- a/core/src/main/scala/com.itv/servicebox/algebra/package.scala
+++ b/core/src/main/scala/com.itv/servicebox/algebra/package.scala
@@ -80,8 +80,8 @@ package object algebra {
   object Service {
 
     case class ReadyCheck[F[_]](isReady: ServiceRegistry.Endpoints => F[Unit],
-                                checkInterval: FiniteDuration,
-                                timeout: FiniteDuration,
+                                attemptTimeout: FiniteDuration,
+                                totalTimeout: FiniteDuration,
                                 label: Option[String] = None)
 
     case class Spec[F[_]](name: String, containers: NonEmptyList[Container.Spec], readyCheck: ReadyCheck[F])

--- a/core/src/test/scala/com/itv/servicebox/test/RunnerTest.scala
+++ b/core/src/test/scala/com/itv/servicebox/test/RunnerTest.scala
@@ -190,8 +190,8 @@ abstract class RunnerTest[F[_]](implicit ec: ExecutionContext, M: MonadError[F, 
         .rabbitSpec[F]
         .copy(
           readyCheck = ReadyCheck(_ => I.lift(counter.getAndIncrement()) >> M.raiseError[Unit](new IllegalStateException(s"Cannot access test service")),
-                                  10.millis,
-                                  30.millis))
+            100.millis,
+            1.second))
 
       I.runSync(withServices(testData.copy(services = List(rabbitSpec))) {
           case _ =>
@@ -200,7 +200,7 @@ abstract class RunnerTest[F[_]](implicit ec: ExecutionContext, M: MonadError[F, 
         .left
         .get shouldBe a[TimeoutException]
 
-      counter.get() should ===(4)
+      counter.get() should ===(11 +- 10)
     }
 
     "recovers from errors when ready-checks eventually succeed" in {


### PR DESCRIPTION
The future instance of scheduler was running ready checks until the totalTimeout elapsed. This fix tries to avoid that, ensuring checks are run just until the complete successfully or they timeout